### PR TITLE
fixes a check for os family

### DIFF
--- a/influxdb/cli.sls
+++ b/influxdb/cli.sls
@@ -1,7 +1,7 @@
 cli_dependencies:
   pkg.installed:
     - pkgs:
-{% if grains['os_family'] == 'Debian' or 'Ubuntu' %}
+{% if grains['os_family'] == 'Debian' %}
       - build-essential
       - ruby-dev
 {% elif grains['os_family'] == 'RedHat' %}

--- a/influxdb/init.sls
+++ b/influxdb/init.sls
@@ -1,7 +1,7 @@
 {% from "influxdb/map.jinja" import map with context %}
 {% from "influxdb/map.jinja" import influxdb with context %}
 
-{% if grains['os_family'] == 'Debian' or 'Ubuntu' %}
+{% if grains['os_family'] == 'Debian' %}
 {% if influxdb['version'] is defined %}
   {% set filename = "influxdb_" + influxdb['version'] + "_" + grains['osarch'] + ".deb" %}
 {% else %}


### PR DESCRIPTION
`$var == "foo" or "bar"` seems to evaluate to "bar" which is truthy all the time...
Even to check for "Ubuntu" is os_family isn't nessesary, Ubuntus os_family is "Debian".