### PR TITLE
Dev influxdb group

### DIFF
--- a/influxdb/init.sls
+++ b/influxdb/init.sls
@@ -53,12 +53,20 @@ influxdb_init:
     - mode: 755
     - template: jinja
 
+influxdb_group:
+  group.present:
+    - name: {{ influxdb_settings.group }}
+    - system: True
+
 influxdb_user:
   user.present:
     - name: {{ influxdb_settings.user }}
     - fullname: {{ influxdb_settings.fullname }}
     - shell: {{ influxdb_settings.shell }}
     - home: {{ influxdb_settings.home }}
+    - gid_from_name: True
+    - require:
+      - group: influxdb_group
 
 influxdb_log:
   file.directory:
@@ -66,6 +74,9 @@ influxdb_log:
     - user: {{ influxdb_settings.user }}
     - group: {{ influxdb_settings.group }}
     - mode: 755
+    - require:
+      - group: influxdb_group
+      - user: influxdb_user
 
 influxdb_logrotate:
   file.managed:

--- a/influxdb/map.jinja
+++ b/influxdb/map.jinja
@@ -1,4 +1,3 @@
-# vi: set ft=sls :
 {%
   set influxdb = {
     "bind-address" : "0.0.0.0",
@@ -21,4 +20,6 @@
   }
 %}
 
-{% do influxdb.update(salt["pillar.get"]("influxdb")) %}
+{% set influxdb = salt["pillar.get"]("influxdb")) %}
+
+# vi: set ft=sls :

--- a/influxdb/map.jinja
+++ b/influxdb/map.jinja
@@ -1,25 +1,57 @@
-{%
-  set influxdb = {
-    "bind-address" : "0.0.0.0",
-    "logging" : {
-      "level" : "info",
-      "directory": "/var/log/influxdb"
+{% set os_map = salt['grains.filter_by']({
+    'Debian': {
+        'conf_dir': '/etc/influxdb',
+        'config': '/etc/influxdb/config.toml',
+        'fullname': 'InfluxDB Service User',
+        'group': 'influxdb',
+        'home': '/opt/influxdb',
+        'init_dir': '/etc/init.d',
+        'logrotate_conf': '/etc/logrotate.d/influxdb',
+        'service': 'influxdb',
+        'shell': '/bin/false',
+        'user': 'influxdb',
     },
-    "admin" : {
-      "port" : "8083"
+    'RedHat': {
+        'conf_dir': '/etc/influxdb',
+        'config': '/etc/influxdb/config.toml',
+        'fullname': 'InfluxDB Service User',
+        'group': 'influxdb',
+        'home': '/opt/influxdb',
+        'init_dir': '/etc/init.d',
+        'logrotate_conf': '/etc/logrotate.d/influxdb',
+        'service': 'influxdb',
+        'shell': '/bin/false',
+        'user': 'influxdb',
     },
-    "api" : {
-      "port" : "8086"
-    },
-    "raft" : {
-      "port" : "8090"
-    },
-    "protobuf" : {
-      "port" : "8083"
-    }
-  }
-%}
+}, merge=salt['pillar.get']('influxdb:lookup')) %}
 
-{% set influxdb = salt["pillar.get"]("influxdb")) %}
+{# Settings dictionary with default values #}
+{% set default_settings = {
+    'influxdb': {
+        "bind-address" : "0.0.0.0",
+        "logging" : {
+            "directory": "/var/log/influxdb",
+            "level" : "info",
+        },
+        "admin" : {
+            "port" : "8083"
+        },
+        "api" : {
+            "port" : "8086"
+        },
+        "raft" : {
+            "port" : "8090"
+        },
+        "protobuf" : {
+            "port" : "8083"
+        }
+    }
+} %}
+
+{# Merge os_map into settings dictionary #}
+{% do default_settings.influxdb.update(os_map) %}
+
+{# Update settings defaults from pillar data #}
+{% set influxdb_settings = salt['pillar.get']('influxdb', default=default_settings.influxdb, merge=True) %}}
 
 # vi: set ft=sls :

--- a/influxdb/templates/config.toml.jinja
+++ b/influxdb/templates/config.toml.jinja
@@ -1,4 +1,3 @@
-# vi: set ft=sls :
 # WARNING: This file is managed by Salt
 # DO NOT EDIT MANUALLY
 
@@ -180,3 +179,5 @@ index-after = 1000
 # the number of requests per one log file, if new requests came in a
 # new log file will be created
 requests-per-logfile = 10000
+
+# vi: set ft=sls :

--- a/influxdb/templates/config.toml.jinja
+++ b/influxdb/templates/config.toml.jinja
@@ -1,28 +1,28 @@
+{% from "influxdb/map.jinja" import influxdb_settings with context -%}
+
 # WARNING: This file is managed by Salt
 # DO NOT EDIT MANUALLY
-
-{% from "influxdb/map.jinja" import influxdb with context %}
 
 # If hostname (on the OS) doesn't return a name that can be resolved by the other
 # systems in the cluster, you'll have to set the hostname to an IP or something
 # that can be resolved here.
 # hostname = ""
 
-bind-address = "{{ influxdb["bind-address"] }}"
+bind-address = "{{ influxdb_settings.get('bind-address') }}"
 
 [logging]
 # logging level can be one of "debug", "info", "warn" or "error"
-level = "{{ influxdb["logging"]["level"] }}"
-file  = "{{ influxdb["logging"]["directory"] }}/influxdb.log"         # stdout to log to standard out
+level = "{{ influxdb_settings.logging.level }}"
+file  = "{{ influxdb_settings.logging.directory }}/influxdb.log"         # stdout to log to standard out
 
 # Configure the admin server
 [admin]
-port   = {{ influxdb["admin"]["port"] }} # binding is disabled if the port isn't set
+port   = {{ influxdb_settings.admin.port }} # binding is disabled if the port isn't set
 assets = "/opt/influxdb/current/admin"
 
 # Configure the http api
 [api]
-port = {{ influxdb["api"]["port"] }} # binding is disabled if the port isn't set
+port = {{ influxdb_settings.api.port }} # binding is disabled if the port isn't set
 # ssl-port = 8084    # Ssl support is enabled if you set a port and cert
 # ssl-cert = /path/to/cert.pem
 
@@ -49,7 +49,7 @@ enabled = false
 # The raft port should be open between all servers in a cluster.
 # However, this port shouldn't be accessible from the internet.
 
-port = {{ influxdb["raft"]["port"] }}
+port = {{ influxdb_settings.raft.port }}
 
 # Where the raft logs are stored. The user running InfluxDB will need read/write access.
 dir  = "/opt/influxdb/shared/data/raft"
@@ -78,7 +78,7 @@ write-buffer-size = 10000
 # This port should be reachable between all servers in a cluster.
 # However, this port shouldn't be accessible from the internet.
 
-protobuf_port = {{ influxdb["protobuf"]["port"] }}
+protobuf_port = {{ influxdb_settings.protobuf.port }}
 
 protobuf_timeout = "2s" # the write timeout on the protobuf conn any duration parseable by time.ParseDuration
 protobuf_heartbeat = "200ms" # the heartbeat interval between the servers. must be parseable by time.ParseDuration

--- a/influxdb/templates/influxdb.service.jinja
+++ b/influxdb/templates/influxdb.service.jinja
@@ -1,5 +1,4 @@
 #! /usr/bin/env bash
-# vi: set ft=sh :
 # WARNING: This file is managed by salt
 # DO NOT EDIT MANUALLY
 
@@ -139,3 +138,5 @@ case $1 in
     exit 2
   ;;
 esac
+
+# vi: set ft=sh :

--- a/influxdb/templates/influxdb.service.jinja
+++ b/influxdb/templates/influxdb.service.jinja
@@ -1,3 +1,4 @@
+{% from "influxdb/map.jinja" import influxdb_settings with context -%}
 #! /usr/bin/env bash
 # WARNING: This file is managed by salt
 # DO NOT EDIT MANUALLY
@@ -90,7 +91,7 @@ case $1 in
     # Log the message appropriately
     cd /
     if which start-stop-daemon > /dev/null 2>&1; then
-      nohup start-stop-daemon --chuid influxdb:influxdb -d / --start --quiet --oknodo --pidfile $pidfile --exec $daemon -- -pidfile $pidfile -config $configfile > /dev/null 2>> {{ pillar["influxdb"]["logging"]["directory"] }}/influxdb_error.log &
+      nohup start-stop-daemon --chuid influxdb:influxdb -d / --start --quiet --oknodo --pidfile $pidfile --exec $daemon -- -pidfile $pidfile -config $configfile > /dev/null 2>> {{ influxdb_settings.logging.directory }}/influxdb_error.log &
     elif set | egrep '^start_daemon' > /dev/null 2>&1; then
       start_daemon -u influxdb ${daemon}-daemon -pidfile $pidfile -config $configfile &
     else

--- a/influxdb/templates/logrotate.conf.jinja
+++ b/influxdb/templates/logrotate.conf.jinja
@@ -1,4 +1,3 @@
-# vi: set ft=sls :
 # WARNING: This file is managed by Salt
 # DO NOT EDIT MANUALLY
 
@@ -12,3 +11,5 @@
   missingok
   su influxdb influxdb
 }
+
+# vi: set ft=sls :

--- a/influxdb/templates/logrotate.conf.jinja
+++ b/influxdb/templates/logrotate.conf.jinja
@@ -1,7 +1,9 @@
+{% from "influxdb/map.jinja" import influxdb_settings with context -%}
+
 # WARNING: This file is managed by Salt
 # DO NOT EDIT MANUALLY
 
-{{ pillar["influxdb"]["logging"]["directory"] }}/*.log {
+{{ influxdb_settings.logging.directory }}/*.log {
   daily
   rotate 3
   copytruncate

--- a/pillar.example
+++ b/pillar.example
@@ -1,9 +1,9 @@
 influxdb:
-  version: 0.8.5
-  bind-address: 0.0.0.0
+  version: '0.8.5'
+  bind-address: '0.0.0.0'
   logging:
+    directory: '/var/log/influxdb'
     level: info
-    directory: /var/log/influxdb
   admin:
     port: 8083
   api:
@@ -12,5 +12,14 @@ influxdb:
     port: 8090
   protobuf:
     port: 8099
+  lookup:
+    config: '/etc/influxdb/config.toml'
+    confdir: '/etc/influxdb'
+    init_dir: '/etc/init.d'
+    logrotate_conf: '/etc/logrotate.d/influxdb'
+    user: influxdb
+    fullname: 'InfluxDB Service User'
+    home: '/opt/influxdb'
+    shell: '/bin/false'
 
 # vi: set ft=yaml :

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,3 @@
-# vi: set ft=yaml :
 influxdb:
   version: 0.8.5
   bind-address: 0.0.0.0
@@ -13,3 +12,5 @@ influxdb:
     port: 8090
   protobuf:
     port: 8099
+
+# vi: set ft=yaml :


### PR DESCRIPTION
This builds on #6 and ensures that the influxdb group that is later being used is created. The group is normally created in the postinst scripts of the Debian packages (not sure about the rpms), but it doesn't hurt to make that requirement explicit (same holds true for the user).