### PR TITLE
Prefix 'user' and 'group' in pillar with 'system_'

### DIFF
--- a/influxdb/init.sls
+++ b/influxdb/init.sls
@@ -50,12 +50,12 @@ influxdb_init:
 
 influxdb_group:
   group.present:
-    - name: {{ influxdb_settings.group }}
+    - name: {{ influxdb_settings.system_group }}
     - system: True
 
 influxdb_user:
   user.present:
-    - name: {{ influxdb_settings.user }}
+    - name: {{ influxdb_settings.system_user }}
     - fullname: {{ influxdb_settings.fullname }}
     - shell: {{ influxdb_settings.shell }}
     - home: {{ influxdb_settings.home }}
@@ -66,8 +66,8 @@ influxdb_user:
 influxdb_log:
   file.directory:
     - name: {{ influxdb_settings.logging.directory }}
-    - user: {{ influxdb_settings.user }}
-    - group: {{ influxdb_settings.group }}
+    - user: {{ influxdb_settings.system_user }}
+    - group: {{ influxdb_settings.system_group }}
     - mode: 755
     - require:
       - group: influxdb_group

--- a/influxdb/map.jinja
+++ b/influxdb/map.jinja
@@ -2,24 +2,24 @@
     'Debian': {
         'config': '/etc/influxdb/config.toml',
         'fullname': 'InfluxDB Service User',
-        'group': 'influxdb',
         'home': '/opt/influxdb',
         'init_dir': '/etc/init.d',
         'logrotate_conf': '/etc/logrotate.d/influxdb',
         'service': 'influxdb',
         'shell': '/bin/false',
-        'user': 'influxdb',
+        'system_group': 'influxdb',
+        'system_user': 'influxdb',
     },
     'RedHat': {
         'config': '/etc/influxdb/config.toml',
         'fullname': 'InfluxDB Service User',
-        'group': 'influxdb',
         'home': '/opt/influxdb',
         'init_dir': '/etc/init.d',
         'logrotate_conf': '/etc/logrotate.d/influxdb',
         'service': 'influxdb',
         'shell': '/bin/false',
-        'user': 'influxdb',
+        'system_group': 'influxdb',
+        'system_user': 'influxdb',
     },
 }, merge=salt['pillar.get']('influxdb:lookup')) %}
 

--- a/pillar.example
+++ b/pillar.example
@@ -15,6 +15,7 @@ influxdb:
   lookup:
     config: '/etc/influxdb/config.toml'
     confdir: '/etc/influxdb'
+    group: influxdb
     init_dir: '/etc/init.d'
     logrotate_conf: '/etc/logrotate.d/influxdb'
     user: influxdb

--- a/pillar.example
+++ b/pillar.example
@@ -13,14 +13,14 @@ influxdb:
   protobuf:
     port: 8099
   lookup:
-    config: '/etc/influxdb/config.toml'
     confdir: '/etc/influxdb'
-    group: influxdb
-    init_dir: '/etc/init.d'
-    logrotate_conf: '/etc/logrotate.d/influxdb'
-    user: influxdb
+    config: '/etc/influxdb/config.toml'
     fullname: 'InfluxDB Service User'
     home: '/opt/influxdb'
+    init_dir: '/etc/init.d'
+    logrotate_conf: '/etc/logrotate.d/influxdb'
     shell: '/bin/false'
+    system_group: influxdb
+    system_user: influxdb
 
 # vi: set ft=yaml :


### PR DESCRIPTION
This is necessary to differentiate the system user, group settings from those
that the influxdb modules will use by default for db maintenance.