### PR TITLE
Drop dependency on pip-formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ Renders the InfluxDB configuration from data provided in the ``influxdb:conf``
 pillar.
 
 It requires the installation of the
-[toml Python module](https://github.com/hit9/toml.py) via pip, for which you
-have to also include the
-[pip-formula](https://github.com/saltstack-formulas/pip-formula).
+[toml Python module](https://github.com/hit9/toml.py) via pip.
 
 The formula ships with default configuration settings for various minor versions
 of InfluxDB. That means that, if you define configuration settings in your

--- a/influxdb/config.sls
+++ b/influxdb/config.sls
@@ -2,13 +2,16 @@
 
 include:
   - influxdb
-  - pip
+
+influxdb_pip:
+  pkg.installed:
+    - name: {{ influxdb_settings.pip_pkg }}
 
 toml-python-module:
   pip.installed:
     - name: {{ influxdb_settings.toml_module }}
     - require:
-      - pkg: pip
+      - pkg: {{ influxdb_settings.pip_pkg }}
 
 influxdb_config:
   file.managed:

--- a/influxdb/defaults.yaml
+++ b/influxdb/defaults.yaml
@@ -8,6 +8,7 @@ influxdb:
     directory: '/var/log/influxdb'
     file: 'influxd.log'
   logrotate_conf: '/etc/logrotate.d/influxdb'
+  pip_pkg: 'python-pip'
   service: 'influxdb'
   shell: '/bin/false'
   system_group: 'influxdb'


### PR DESCRIPTION
We do not want interformula dependency at this point and therefore just
maintain a complete copy of the pip-formula settings in this formula.

Luckily the pip package name seems to be identical on, at least, Debian
and RedHat and their derivatives.