### PR TITLE
Switch home directory to DATA_DIR

### DIFF
--- a/influxdb/defaults.yaml
+++ b/influxdb/defaults.yaml
@@ -3,7 +3,7 @@ influxdb:
   conf: {}
   etc_default: '/etc/default/influxdb'
   fullname: 'InfluxDB Service User'
-  home: '/opt/influxdb'
+  home: '/var/lib/influxdb'
   logging:
     directory: '/var/log/influxdb'
     file: 'influxd.log'


### PR DESCRIPTION
InfluxDB uses DATA_DIR in their postinst script which defaults to
/var/lib/influxdb.