### PR TITLE
fix(init): replace `gid_from_name` (deprecated in `develop`)

### DIFF
--- a/influxdb/init.sls
+++ b/influxdb/init.sls
@@ -70,7 +70,7 @@ influxdb_user:
     - fullname: {{ influxdb_settings.fullname }}
     - shell: {{ influxdb_settings.shell }}
     - home: {{ influxdb_settings.home }}
-    - gid_from_name: True
+    - gid: {{ influxdb_settings.system_user }}
     - require:
       - group: influxdb_group
 


### PR DESCRIPTION
* Need to merge before #24 since it prevents testing on `develop`
* Solution based upon:
  - saltstack-formulas/vault-formula#35
  - saltstack-formulas/users-formula#204

---

CC: @n-rodriguez.  Example of `develop` images working here:

* https://travis-ci.org/myii/influxdb-formula/builds/576254627